### PR TITLE
fix(middleware): improve case-insensitive env mode checking

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -66,7 +66,7 @@ export async function middleware(request: NextRequest) {
       return NextResponse.redirect(url);
     }
 
-    const isLocalMode = process.env.NEXT_PUBLIC_ENV_MODE === 'local'
+    const isLocalMode = process.env.NEXT_PUBLIC_ENV_MODE?.toLowerCase() === 'local'
     if (isLocalMode) {
       return supabaseResponse;
     }


### PR DESCRIPTION
## Summary
- Use `toLowerCase()` for case-insensitive environment mode checking
- Replace explicit case matching with more robust solution

## Problem
The setup.py generates `NEXT_PUBLIC_ENV_MODE=LOCAL` (uppercase) but the original code only checked lowercase, requiring additional case handling.

## Solution
```typescript
// Before
process.env.NEXT_PUBLIC_ENV_MODE === 'local'

// After  
process.env.NEXT_PUBLIC_ENV_MODE?.toLowerCase() === 'local'
```

This ensures middleware works regardless of case variation and handles undefined values safely.